### PR TITLE
Dioxus: Enable wasm-opt for trunk

### DIFF
--- a/frameworks/keyed/dioxus/trunk.html
+++ b/frameworks/keyed/dioxus/trunk.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Dioxus</title>
     <link href="/css/currentStyle.css" rel="stylesheet"/>
+    <link data-trunk rel="rust" data-wasm-opt="z" />    
 </head>
 <body>
 <div id='main'></div>


### PR DESCRIPTION
Turns on size optimizations for trunk in the Dioxus framework.